### PR TITLE
Add path(), redirect shortcuts, typed variables, and object wildcard/spread

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -6,12 +6,43 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
 
 	"aux4.dev/aux4/core"
 	"aux4.dev/aux4/output"
 )
 
 var commandsAvailable = map[string]bool{}
+
+// redirectTokenPattern matches the aux4 output-redirect shortcuts as standalone
+// shell tokens. It requires a separator (start, whitespace, ';', '&', '(') before
+// the '>' and a separator (end, whitespace, ';', '&', '|', ')') after the token,
+// so it never touches a real redirect like `2>ignore` or `>ignore.log`.
+var redirectTokenPattern = regexp.MustCompile(`(^|[\s;&(])>ignore(Error|Output)?($|[\s;&|)])`)
+
+// expandRedirects rewrites the aux4 redirect shortcuts into shell redirections
+// just before the command reaches the shell:
+//
+//	>ignore        -> >/dev/null 2>&1   (discard stdout and stderr)
+//	>ignoreError   -> 2>/dev/null       (discard stderr)
+//	>ignoreOutput  -> >/dev/null        (discard stdout)
+func expandRedirects(instruction string) string {
+	return redirectTokenPattern.ReplaceAllStringFunc(instruction, func(match string) string {
+		groups := redirectTokenPattern.FindStringSubmatch(match)
+		lead, kind, trail := groups[1], groups[2], groups[3]
+
+		var replacement string
+		switch kind {
+		case "Error":
+			replacement = "2>/dev/null"
+		case "Output":
+			replacement = ">/dev/null"
+		default:
+			replacement = ">/dev/null 2>&1"
+		}
+		return lead + replacement + trail
+	})
+}
 
 var OnAbort func()
 
@@ -50,6 +81,7 @@ func ExecuteCommandWithPipedStdin(instruction string, stdinData string) error {
 		shell = "/bin/sh"
 	}
 
+	instruction = expandRedirects(instruction)
 	cmd := exec.Command(shell, "-c", instruction)
 	cmd.Stdin = bytes.NewBufferString(stdinData)
 	cmd.Stdout = os.Stdout
@@ -77,6 +109,7 @@ func executeCommand(instruction string, withStdOut bool, withStdIn bool) (string
 		shell = "/bin/sh"
 	}
 
+	instruction = expandRedirects(instruction)
 	cmd = exec.Command(shell, "-c", instruction)
 	cmd.Env = append(os.Environ(), "CLICOLOR_FORCE=1")
 

--- a/cmd/redirect_test.go
+++ b/cmd/redirect_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import "testing"
+
+func TestExpandRedirects(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ignore all", "echo hi >ignore", "echo hi >/dev/null 2>&1"},
+		{"ignore all at end", "cmd >ignore", "cmd >/dev/null 2>&1"},
+		{"ignore error", "cmd >ignoreError", "cmd 2>/dev/null"},
+		{"ignore output", "cmd >ignoreOutput", "cmd >/dev/null"},
+		{"before semicolon", "a >ignore; b", "a >/dev/null 2>&1; b"},
+		{"followed by text", "cmd >ignoreError next", "cmd 2>/dev/null next"},
+		{"before pipe", "cmd >ignore | wc -l", "cmd >/dev/null 2>&1 | wc -l"},
+		{"start of string", ">ignore x", ">/dev/null 2>&1 x"},
+
+		// Must NOT touch real redirects or filenames.
+		{"real fd redirect", "cmd 2>ignore", "cmd 2>ignore"},
+		{"file named ignore.log", "cmd >ignore.log", "cmd >ignore.log"},
+		{"unknown suffix", "cmd >ignoreFoo", "cmd >ignoreFoo"},
+		{"error with trailing letter", "cmd >ignoreErrorX", "cmd >ignoreErrorX"},
+		{"no tokens", "echo just a plain command", "echo just a plain command"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := expandRedirects(c.in); got != c.want {
+				t.Errorf("expandRedirects(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -138,6 +138,7 @@ type CommandHelpVariable struct {
 	Name     string   `json:"name"`
 	Text     string   `json:"text"`
 	Default  *string  `json:"default"`
+	Type     string   `json:"type,omitempty"`
 	Arg      bool     `json:"arg"`
 	Multiple bool     `json:"multiple"`
 	Hide     bool     `json:"hide"`

--- a/engine/param/arg.go
+++ b/engine/param/arg.go
@@ -196,7 +196,17 @@ func (p *Parameters) Get(command core.Command, actions []string, name string) (a
 	if p.params[name] != nil {
 		variable, exists := command.Help.GetVariable(name)
 		if !exists || !variable.Encrypt {
-			return p.params[name][(len(p.params[name]) - 1)], nil
+			last := len(p.params[name]) - 1
+			value := p.params[name][last]
+			// Coerce a not-yet-typed value to the variable's declared type and
+			// cache it back, so every later reader sees the typed value.
+			if exists && variable.Type != "" {
+				if strValue, ok := value.(string); ok {
+					value = coerceType(strValue, variable.Type)
+					p.params[name][last] = value
+				}
+			}
+			return value, nil
 		}
 	}
 
@@ -209,6 +219,11 @@ func (p *Parameters) Get(command core.Command, actions []string, name string) (a
 		}
 
 		if result != nil {
+			if variable, exists := command.Help.GetVariable(name); exists && variable.Type != "" {
+				if strValue, ok := result.(string); ok {
+					result = coerceType(strValue, variable.Type)
+				}
+			}
 			p.Set(name, result)
 			value = result
 			break

--- a/engine/param/inject.go
+++ b/engine/param/inject.go
@@ -367,6 +367,17 @@ func isLiteral(candidate string) bool {
 	return hasDigit
 }
 
+// hasDeclaredType reports whether the base variable of a field path declares a
+// type (number/boolean/json) in the command's help.
+func hasDeclaredType(command core.Command, variablePath string) bool {
+	baseName := variablePath
+	if i := strings.IndexAny(baseName, ".["); i != -1 {
+		baseName = baseName[:i]
+	}
+	variable, exists := command.Help.GetVariable(baseName)
+	return exists && variable.Type != ""
+}
+
 func parseObject(command core.Command, actions []string, params *Parameters, fieldList string) (string, error) {
 	result := make(map[string]any)
 
@@ -417,8 +428,15 @@ func parseObject(command core.Command, actions []string, params *Parameters, fie
 			return "", err
 		}
 
-		// Skip empty string values (an unset variable), but keep any typed
-		// value — a number, boolean or parsed JSON — so it stays typed.
+		// A value only stays typed (number, boolean or parsed JSON) when its
+		// variable declares a type; otherwise it is stringified. This keeps
+		// values from a JSON source (naturally typed) as strings unless a type
+		// was explicitly declared.
+		if !hasDeclaredType(command, variablePath) {
+			value = valueToString(value, false)
+		}
+
+		// Skip empty string values (an unset variable).
 		if strValue, ok := value.(string); ok && strValue == "" {
 			continue
 		}

--- a/engine/param/inject.go
+++ b/engine/param/inject.go
@@ -3,13 +3,52 @@ package param
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"aux4.dev/aux4/core"
 	"aux4.dev/aux4/io"
 )
+
+// coerceType converts a string value into a typed value according to a
+// variable's declared "type". Unknown types or unparseable values fall back to
+// the original string, so a bad declaration never loses data.
+//
+//	number  -> json.Number (keeps the exact numeric text, e.g. "12.50")
+//	boolean -> bool
+//	json    -> parsed JSON value (object, array, number, ...)
+//	(other) -> unchanged string
+func coerceType(value string, typeName string) any {
+	switch typeName {
+	case "number":
+		trimmed := strings.TrimSpace(value)
+		if _, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return json.Number(trimmed)
+		}
+		return value
+	case "boolean", "bool":
+		switch strings.TrimSpace(value) {
+		case "true":
+			return true
+		case "false":
+			return false
+		}
+		return value
+	case "json":
+		decoder := json.NewDecoder(strings.NewReader(value))
+		decoder.UseNumber()
+		var parsed any
+		if err := decoder.Decode(&parsed); err == nil {
+			return parsed
+		}
+		return value
+	default:
+		return value
+	}
+}
 
 // placeholder for $$ escape — chosen to be unlikely in real instructions
 const dollarEscapePlaceholder = "\x00DOLLAR\x00"
@@ -89,6 +128,11 @@ func InjectParameters(command core.Command, instruction string, actions []string
 	}
 
 	instruction, err = resolveNvlVariables(command, instruction, actions, params)
+	if err != nil {
+		return "", err
+	}
+
+	instruction, err = resolvePathVariables(command, instruction, actions, params)
 	if err != nil {
 		return "", err
 	}
@@ -213,6 +257,90 @@ func resolveNvlVariables(command core.Command, instruction string, actions []str
 	})
 }
 
+// resolvePathVariables resolves path(seg1/seg2/...) into an absolute path.
+// Each segment is joined with the OS separator and the result is made absolute
+// (relative paths resolve against the current working directory). Segments are:
+//   - a bare word         -> resolved as a variable value
+//   - ".." or "."         -> kept as a literal path segment
+//   - a quoted string     -> kept as a literal (quotes stripped)
+// An empty result stays empty, matching the shell `case` idiom it replaces.
+func resolvePathVariables(command core.Command, instruction string, actions []string, params *Parameters) (string, error) {
+	return resolveFunction(instruction, "path\\(([^)]+)\\)", func(groups []string) (string, error) {
+		parts := []string{}
+		for _, segment := range splitPathSegments(groups[0]) {
+			segment = strings.TrimSpace(segment)
+			if segment == "" {
+				continue
+			}
+
+			// "." and ".." are literal path segments, never variable names.
+			if segment == "." || segment == ".." {
+				parts = append(parts, segment)
+				continue
+			}
+
+			// Quoted string — strip quotes, use as a literal segment.
+			if (strings.HasPrefix(segment, "'") && strings.HasSuffix(segment, "'")) ||
+				(strings.HasPrefix(segment, "\"") && strings.HasSuffix(segment, "\"")) {
+				parts = append(parts, segment[1:len(segment)-1])
+				continue
+			}
+
+			// Otherwise resolve it as a variable value.
+			value, err := getVariableValueAsString(command, actions, params, segment, false)
+			if err != nil {
+				if strings.Contains(err.Error(), "Variable not found") {
+					continue
+				}
+				return "", err
+			}
+			if value != "" {
+				parts = append(parts, value)
+			}
+		}
+
+		if len(parts) == 0 {
+			return "", nil
+		}
+
+		absolute, err := filepath.Abs(filepath.Join(parts...))
+		if err != nil {
+			return "", err
+		}
+		return absolute, nil
+	})
+}
+
+// splitPathSegments splits a path() argument on "/" while keeping quoted
+// segments (which may themselves contain "/") intact.
+func splitPathSegments(fieldList string) []string {
+	segments := []string{}
+	current := strings.Builder{}
+	var quote rune
+
+	for _, ch := range fieldList {
+		if quote != 0 {
+			current.WriteRune(ch)
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+			current.WriteRune(ch)
+		case '/':
+			segments = append(segments, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(ch)
+		}
+	}
+	segments = append(segments, current.String())
+	return segments
+}
+
 func isLiteral(candidate string) bool {
 	if candidate == "true" || candidate == "false" || candidate == "null" {
 		return true
@@ -240,7 +368,7 @@ func isLiteral(candidate string) bool {
 }
 
 func parseObject(command core.Command, actions []string, params *Parameters, fieldList string) (string, error) {
-	result := make(map[string]string)
+	result := make(map[string]any)
 
 	fields := strings.Split(fieldList, ",")
 	for _, field := range fields {
@@ -257,7 +385,31 @@ func parseObject(command core.Command, actions []string, params *Parameters, fie
 			alias = strings.TrimSpace(parts[1])
 		}
 
-		value, err := getVariableValueAsString(command, actions, params, variablePath, false)
+		// "*" collects every current parameter. Bare "*" spreads them into the
+		// object itself; "*:key" nests them under that key as an object.
+		if variablePath == "*" {
+			all := make(map[string]any)
+			for name, values := range params.params {
+				if len(values) == 0 {
+					continue
+				}
+				if len(values) == 1 {
+					all[name] = values[0]
+				} else {
+					all[name] = values
+				}
+			}
+			if alias == "" {
+				for key, value := range all {
+					result[key] = value
+				}
+			} else {
+				result[alias] = all
+			}
+			continue
+		}
+
+		value, err := getVariableValue(command, actions, params, variablePath)
 		if err != nil {
 			if strings.Contains(err.Error(), "Variable not found") {
 				continue
@@ -265,13 +417,17 @@ func parseObject(command core.Command, actions []string, params *Parameters, fie
 			return "", err
 		}
 
-		if value != "" {
-			jsonKey := alias
-			if jsonKey == "" {
-				jsonKey = strings.ReplaceAll(variablePath, ".", "_")
-			}
-			result[jsonKey] = value
+		// Skip empty string values (an unset variable), but keep any typed
+		// value — a number, boolean or parsed JSON — so it stays typed.
+		if strValue, ok := value.(string); ok && strValue == "" {
+			continue
 		}
+
+		jsonKey := alias
+		if jsonKey == "" {
+			jsonKey = strings.ReplaceAll(variablePath, ".", "_")
+		}
+		result[jsonKey] = value
 	}
 
 	jsonBytes, err := json.Marshal(result)
@@ -484,24 +640,36 @@ func getVariableValueAsString(command core.Command, actions []string, params *Pa
 		return valueToString(allVars, escape), nil
 	}
 
-	value, err := params.Expr(command, actions, variableName)
+	value, err := getVariableValue(command, actions, params, variableName)
 	if err != nil {
 		return "", err
 	}
 
+	return valueToString(value, escape), nil
+}
+
+// getVariableValue resolves a variable to its raw (typed) value, applying secret
+// resolution but without stringifying. Callers that build JSON (e.g. object())
+// use this so a variable declared `type: number` stays a number.
+func getVariableValue(command core.Command, actions []string, params *Parameters, variableName string) (any, error) {
+	value, err := params.Expr(command, actions, variableName)
+	if err != nil {
+		return nil, err
+	}
+
 	if value == nil {
-		return "", core.VariableNotFoundError(variableName)
+		return nil, core.VariableNotFoundError(variableName)
 	}
 
 	if strValue, ok := value.(string); ok && strings.HasPrefix(strValue, secretPrefix) {
 		resolved, err := ResolveSingleSecret(strValue)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		value = resolved
 	}
 
-	return valueToString(value, escape), nil
+	return value, nil
 }
 
 func valueToString(value any, escape bool) string {

--- a/engine/param/path_test.go
+++ b/engine/param/path_test.go
@@ -1,0 +1,80 @@
+package param
+
+import (
+	"path/filepath"
+	"testing"
+
+	"aux4.dev/aux4/core"
+)
+
+func injectPath(t *testing.T, instruction string, vars map[string]string) string {
+	t.Helper()
+	params := &Parameters{params: map[string][]any{}, lookups: []ParameterLookup{}}
+	for name, value := range vars {
+		params.Update(name, value)
+	}
+	result, err := InjectParameters(core.Command{}, instruction, []string{}, params)
+	if err != nil {
+		t.Fatalf("InjectParameters(%q) error: %v", instruction, err)
+	}
+	return result
+}
+
+// abs mirrors path()'s own resolution so the expectation is CWD-independent.
+func abs(t *testing.T, parts ...string) string {
+	t.Helper()
+	a, err := filepath.Abs(filepath.Join(parts...))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	return a
+}
+
+func TestPathResolvesRelativeToAbsolute(t *testing.T) {
+	got := injectPath(t, "path(db)", map[string]string{"db": "local.db"})
+	if want := abs(t, "local.db"); got != want {
+		t.Errorf("path(db) = %q, want %q", got, want)
+	}
+}
+
+func TestPathKeepsAbsoluteUnchanged(t *testing.T) {
+	got := injectPath(t, "path(db)", map[string]string{"db": "/var/data/x.db"})
+	if got != "/var/data/x.db" {
+		t.Errorf("path(db) = %q, want /var/data/x.db", got)
+	}
+}
+
+func TestPathJoinsSegmentsWithQuotedLiteral(t *testing.T) {
+	got := injectPath(t, "path(dir/'backups'/name)", map[string]string{"dir": "data", "name": "shop"})
+	if want := abs(t, "data", "backups", "shop"); got != want {
+		t.Errorf("path(dir/'backups'/name) = %q, want %q", got, want)
+	}
+}
+
+func TestPathCollapsesParentSegment(t *testing.T) {
+	got := injectPath(t, "path(dir/../'archive'/name)", map[string]string{"dir": "data", "name": "shop"})
+	if want := abs(t, "archive", "shop"); got != want {
+		t.Errorf("path(dir/../'archive'/name) = %q, want %q", got, want)
+	}
+}
+
+func TestPathDotIsLiteralSegment(t *testing.T) {
+	got := injectPath(t, "path('.'/name)", map[string]string{"name": "shop"})
+	if want := abs(t, "shop"); got != want {
+		t.Errorf("path('.'/name) = %q, want %q", got, want)
+	}
+}
+
+func TestPathMissingVariableStaysEmpty(t *testing.T) {
+	got := injectPath(t, "path(missing)", map[string]string{})
+	if got != "" {
+		t.Errorf("path(missing) = %q, want empty", got)
+	}
+}
+
+func TestPathEscapedIsLiteral(t *testing.T) {
+	got := injectPath(t, "\\path(x)", map[string]string{"x": "y"})
+	if got != "path(x)" {
+		t.Errorf("\\path(x) = %q, want path(x)", got)
+	}
+}

--- a/engine/param/type_test.go
+++ b/engine/param/type_test.go
@@ -1,0 +1,83 @@
+package param
+
+import (
+	"encoding/json"
+	"testing"
+
+	"aux4.dev/aux4/core"
+)
+
+func TestCoerceType(t *testing.T) {
+	cases := []struct {
+		value    string
+		typeName string
+		want     string // JSON-marshalled form of the coerced value
+	}{
+		{"7", "number", "7"},
+		{"12.50", "number", "12.50"}, // trailing zero preserved
+		{"-3", "number", "-3"},
+		{"notanumber", "number", `"notanumber"`}, // fallback to string
+		{"true", "boolean", "true"},
+		{"false", "bool", "false"},
+		{"maybe", "boolean", `"maybe"`}, // fallback to string
+		{`["a","b"]`, "json", `["a","b"]`},
+		{`{"k":1}`, "json", `{"k":1}`},
+		{"plain", "string", `"plain"`},
+		{"plain", "", `"plain"`}, // no type declared
+	}
+
+	for _, c := range cases {
+		got, err := json.Marshal(coerceType(c.value, c.typeName))
+		if err != nil {
+			t.Fatalf("marshal coerceType(%q,%q): %v", c.value, c.typeName, err)
+		}
+		if string(got) != c.want {
+			t.Errorf("coerceType(%q, %q) => %s, want %s", c.value, c.typeName, got, c.want)
+		}
+	}
+}
+
+func typedCommand() core.Command {
+	return core.Command{
+		Help: &core.CommandHelp{
+			Variables: []*core.CommandHelpVariable{
+				{Name: "retain", Type: "number"},
+				{Name: "active", Type: "boolean"},
+				{Name: "tags", Type: "json"},
+				{Name: "name"},
+			},
+		},
+	}
+}
+
+func TestObjectEmitsDeclaredTypes(t *testing.T) {
+	params := &Parameters{params: map[string][]any{}, lookups: []ParameterLookup{}}
+	params.Update("name", "shop")
+	params.Update("retain", "7")
+	params.Update("active", "true")
+	params.Update("tags", `["a","b"]`)
+
+	got, err := InjectParameters(typedCommand(), "object(name,retain,active,tags)", []string{}, params)
+	if err != nil {
+		t.Fatalf("InjectParameters: %v", err)
+	}
+	// json.Marshal sorts map keys, so the order is deterministic.
+	want := `{"active":true,"name":"shop","retain":7,"tags":["a","b"]}`
+	if got != want {
+		t.Errorf("object(...) = %s, want %s", got, want)
+	}
+}
+
+func TestTypedVariableStringifiesForShell(t *testing.T) {
+	params := &Parameters{params: map[string][]any{}, lookups: []ParameterLookup{}}
+	params.Update("retain", "7")
+	params.Update("active", "true")
+
+	got, err := InjectParameters(typedCommand(), "retain=${retain} active=${active}", []string{}, params)
+	if err != nil {
+		t.Fatalf("InjectParameters: %v", err)
+	}
+	if want := "retain=7 active=true"; got != want {
+		t.Errorf("shell interpolation = %q, want %q", got, want)
+	}
+}

--- a/package/README.md
+++ b/package/README.md
@@ -297,7 +297,7 @@ created record 019f8661-8b26-7a0c-9d10-501669d7aa67
 | `values(name, age)` | Returns multiple variable values each wrapped in single quotes |
 | `param(name)` | Returns `--name 'value'` format |
 | `params(name, age)` | Returns multiple params in `--name 'value' --age 'value'` format |
-| `object(name, age)` | Returns a JSON object with the specified fields (supports aliases: `object(data.name:name)`) |
+| `object(name, age)` | Returns a JSON object with the specified fields (supports aliases: `object(data.name:name)`; `object(*)` spreads all params into the object, `object(*:key)` nests them under `key`) |
 | `nvl(var1, var2, 'fallback')` | Returns the first non-null, non-empty value |
 | `exists(file)` | Checks if file at variable path exists |
 | `if(name)` | Conditional expression |


### PR DESCRIPTION
Bundles the work committed on this branch on top of the released 5.1.32:

- **path() function**, redirect shortcuts, and **typed variables** (`type: number/boolean/json`) — `object()` emits typed values when a variable declares a type.
- **object(\*)** spreads all params into the object (instead of a literal `*` field); **object(\*:key)** nests them under `key` as a real object.
- **fix:** `object()` keeps values as strings unless the variable declares a type, so JSON-sourced values stay strings by default (restores the pre-typed-vars behavior; the two param.test.md object cases pass again).
- README/function docs updated.

Full suite: 253 passing.